### PR TITLE
Markdown HTML support

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -2,7 +2,6 @@
 
 ## Todos
 
-- markdown: implement html block handler
 - markdown: make sure there's proper HTML escaping where it needs to be
 - dinomark: implement `${var.interpolation}` inline handler
 - dinomark: implement `[@var] key (jsonValue)` block handler
@@ -11,3 +10,5 @@
 - documentation: fill out more
 
 ## Done
+
+- markdown: implement html block handler

--- a/src/inline/state-buffer.ts
+++ b/src/inline/state-buffer.ts
@@ -44,7 +44,6 @@ export class InlineStateBuffer implements InlineFormatterInterface {
     } else {
       // 1+ levels deep
       let action = cur.nextAction(lex);
-
       if (actionShouldUseNewHandler(action)) {
         if (this.wasNewHandlerFoundAndPushedForLex(lex, def)) {
           return;

--- a/src/plugins/markdown/html.test.ts
+++ b/src/plugins/markdown/html.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "chai";
+import { startHtmlTagLookahead } from "./lexdef.lookaheads";
+import { DocProcessor } from "../../doc-processor";
+import { LinkHandler } from "./inline/link";
+import { InlineActions } from "../../types";
+import { EnclosingTagState, HtmlBlockHandler } from "./html";
+import exp = require("constants");
+
+describe.only("plugins.markdown.html", () => {
+  describe("lex.commonmark: startHtmlTagLookahead()", () => {
+    it("matches start of html tag '<html:body key=val'", () => {
+      const lookahead = startHtmlTagLookahead("<html:body key=val", "<", 1, {
+        priority: 1,
+      });
+      expect(lookahead.newLexeme).to.equal("<html:body");
+    });
+  });
+  describe("HtmlBlockHandler", () => {
+    const docproc = new DocProcessor();
+    let subject: HtmlBlockHandler | any = {};
+
+    let actions: InlineActions[] = [];
+    beforeEach(() => {
+      subject = new HtmlBlockHandler();
+      subject.setContext(docproc.makeContext());
+      actions = [];
+    });
+
+    const buildHtml = (lexemes: string[]) => {
+      lexemes.forEach((lex) => {
+        actions.push(subject.push(lex));
+      });
+    };
+
+    it("builds html as expected", () => {
+      buildHtml([
+        "<div",
+        " key='val'",
+        ">",
+        "body",
+        " ",
+        "is",
+        " ",
+        "**",
+        "bold",
+        "**",
+        "</div",
+        ">",
+      ]);
+      expect(subject.toString()).to.equal(
+        "<div key='val'>body is **bold**</div>"
+      );
+      expect(subject.state).to.equal(EnclosingTagState.tag_closed);
+    });
+  });
+});

--- a/src/plugins/markdown/html.test.ts
+++ b/src/plugins/markdown/html.test.ts
@@ -42,5 +42,14 @@ describe.only("plugins.markdown.html", () => {
       dc.process("<style>body is **bold**</style>");
       expect(dc.toString()).to.equal("<style>body is **bold**</style>");
     });
+
+    it("ignores markup in attributes", () => {
+      const dc = new DocProcessor(docproc.makeContext());
+      dc.process("<span key='**val**'>body is **bold**</span>");
+      expect(dc.toString()).to.equal(
+        "<p><span key='**val**'>body is <strong>bold</strong></span></p>"
+      );
+    });
   });
+  describe("HtmlTagHandler", () => {});
 });

--- a/src/plugins/markdown/html.test.ts
+++ b/src/plugins/markdown/html.test.ts
@@ -22,10 +22,25 @@ describe.only("plugins.markdown.html", () => {
     registerPlugin(docproc);
 
     it("builds html as expected", () => {
-      docproc.process("<div key='val'>body is **bold**</div>");
-      expect(docproc.toString()).to.equal(
+      const dc = new DocProcessor(docproc.makeContext());
+      dc.process("<div key='val'>body is **bold**</div>");
+      expect(dc.toString()).to.equal(
         "<div key='val'>body is <strong>bold</strong></div>"
       );
+    });
+
+    it("ignores non-block tag", () => {
+      const dc = new DocProcessor(docproc.makeContext());
+      dc.process("<span key='val'>body is **bold**</span>");
+      expect(dc.toString()).to.equal(
+        "<p><span key='val'>body is <strong>bold</strong></span></p>"
+      );
+    });
+
+    it("passes content through for <style> body", () => {
+      const dc = new DocProcessor(docproc.makeContext());
+      dc.process("<style>body is **bold**</style>");
+      expect(dc.toString()).to.equal("<style>body is **bold**</style>");
     });
   });
 });

--- a/src/plugins/markdown/html.test.ts
+++ b/src/plugins/markdown/html.test.ts
@@ -24,7 +24,7 @@ describe.only("plugins.markdown.html", () => {
     it("builds html as expected", () => {
       docproc.process("<div key='val'>body is **bold**</div>");
       expect(docproc.toString()).to.equal(
-        "<div key='val'>body is **bold**</div>"
+        "<div key='val'>body is <strong>bold</strong></div>"
       );
     });
   });

--- a/src/plugins/markdown/html.test.ts
+++ b/src/plugins/markdown/html.test.ts
@@ -5,6 +5,8 @@ import { LinkHandler } from "./inline/link";
 import { InlineActions } from "../../types";
 import { EnclosingTagState, HtmlBlockHandler } from "./html";
 import exp = require("constants");
+import { registerPlugin } from "./index";
+import doc = Mocha.reporters.doc;
 
 describe.only("plugins.markdown.html", () => {
   describe("lex.commonmark: startHtmlTagLookahead()", () => {
@@ -17,40 +19,13 @@ describe.only("plugins.markdown.html", () => {
   });
   describe("HtmlBlockHandler", () => {
     const docproc = new DocProcessor();
-    let subject: HtmlBlockHandler | any = {};
-
-    let actions: InlineActions[] = [];
-    beforeEach(() => {
-      subject = new HtmlBlockHandler();
-      subject.setContext(docproc.makeContext());
-      actions = [];
-    });
-
-    const buildHtml = (lexemes: string[]) => {
-      lexemes.forEach((lex) => {
-        actions.push(subject.push(lex));
-      });
-    };
+    registerPlugin(docproc);
 
     it("builds html as expected", () => {
-      buildHtml([
-        "<div",
-        " key='val'",
-        ">",
-        "body",
-        " ",
-        "is",
-        " ",
-        "**",
-        "bold",
-        "**",
-        "</div",
-        ">",
-      ]);
-      expect(subject.toString()).to.equal(
+      docproc.process("<div key='val'>body is **bold**</div>");
+      expect(docproc.toString()).to.equal(
         "<div key='val'>body is **bold**</div>"
       );
-      expect(subject.state).to.equal(EnclosingTagState.tag_closed);
     });
   });
 });

--- a/src/plugins/markdown/html.ts
+++ b/src/plugins/markdown/html.ts
@@ -1,1 +1,127 @@
 // @todo html handler that allows block-level elements (div, blockquote, table, p, aside, header, nav, dl)
+
+import { BlockBase } from "../../defaults/block-base";
+import {
+  BlockActions,
+  BlockHandlerType,
+  HandlerInterface,
+  LexemeDef,
+} from "../../types";
+import { REGEX_HTML_TAG_UNVALIDATED_START_OPEN } from "./lexdef.lookaheads";
+
+export enum EnclosingTagState {
+  start,
+  tag_starting,
+  tag_open,
+  tag_closing,
+  tag_closed,
+}
+
+export class HtmlBlockHandler
+  extends BlockBase
+  implements HandlerInterface<BlockHandlerType> {
+  canAccept(lexeme: string, def: LexemeDef | undefined): boolean {
+    return REGEX_HTML_TAG_UNVALIDATED_START_OPEN.test(lexeme);
+  }
+
+  cloneInstance(): HandlerInterface<BlockHandlerType> {
+    return new HtmlBlockHandler();
+  }
+
+  getName(): string {
+    return "html-block";
+  }
+
+  handlerEnd(): void {}
+
+  lastLex = "";
+  state: EnclosingTagState = EnclosingTagState.start;
+  buff: any[] = [];
+
+  push(lexeme: string, def: LexemeDef | undefined): any {
+    let ret = BlockActions.REJECT;
+    switch (this.state) {
+      case EnclosingTagState.start:
+        ret = this.handleStart(lexeme, def);
+        break;
+      case EnclosingTagState.tag_starting:
+        ret = this.handleTagStarting(lexeme, def);
+        break;
+      case EnclosingTagState.tag_open:
+        ret = this.handleTagOpen(lexeme, def);
+        break;
+      case EnclosingTagState.tag_closing:
+        ret = this.handleTagClosing(lexeme, def);
+        break;
+      case EnclosingTagState.tag_closed:
+        ret = this.handleTagClosed(lexeme, def);
+        break;
+    }
+
+    this.lastLex = lexeme;
+    return ret;
+  }
+
+  tagCloseStart = "";
+
+  private handleStart(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): BlockActions {
+    // @todo verify lexeme as tag open?
+    this.buff.push(lexeme);
+    this.tagCloseStart = "</" + lexeme.substr(1);
+    this.state = EnclosingTagState.tag_starting;
+    return BlockActions.CONTINUE;
+  }
+
+  private handleTagStarting(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): BlockActions {
+    this.buff.push(lexeme);
+    if (lexeme == ">") {
+      this.state = EnclosingTagState.tag_open;
+      // for now, we're treating everything between open and close as a single block
+      this.buff.push(this.inlineFormatter);
+    }
+    return BlockActions.CONTINUE;
+  }
+
+  private handleTagOpen(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): BlockActions {
+    if (lexeme === this.tagCloseStart) {
+      this.buff.push(lexeme);
+      this.state = EnclosingTagState.tag_closing;
+    } else {
+      this.inlineFormatter.push(lexeme, def);
+    }
+    return BlockActions.CONTINUE;
+  }
+
+  private handleTagClosing(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): BlockActions {
+    if (lexeme == ">") {
+      this.state = EnclosingTagState.tag_closed;
+      this.buff.push(lexeme);
+      return BlockActions.DONE;
+    }
+
+    return BlockActions.REJECT;
+  }
+
+  private handleTagClosed(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): BlockActions {
+    return BlockActions.REJECT;
+  }
+
+  toString() {
+    return this.buff.join("");
+  }
+}

--- a/src/plugins/markdown/html.ts
+++ b/src/plugins/markdown/html.ts
@@ -45,6 +45,10 @@ export enum EnclosingTagState {
   tag_closed,
 }
 
+/**
+ * Detects block-level tags and treats its content as a single block. For LiteralBodyTags,
+ * all content is passed through as-is.
+ */
 export class HtmlBlockHandler
   extends BlockBase
   implements HandlerInterface<BlockHandlerType> {

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -19,6 +19,7 @@ import { CodeHandler as InlineCodeHandler } from "./inline/code";
 import { StrikeHandler } from "./inline/strike";
 import { ImageHandler, LinkHandler } from "./inline/link";
 import { HtmlBlockHandler } from "./html";
+import { HtmlTagHandler } from "./inline/html-tag";
 
 export const registerPlugin = (
   processor: DocProcessor,
@@ -38,6 +39,7 @@ export const registerPlugin = (
   bm.addHandler(new ParagraphHandler());
 
   const im = processor.getInlineManager();
+  im.addHandler(new HtmlTagHandler());
   im.addHandler(new BoldHandler());
   im.addHandler(new ItalicHandler());
   im.addHandler(new StrongHandler());

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -18,6 +18,7 @@ import {
 import { CodeHandler as InlineCodeHandler } from "./inline/code";
 import { StrikeHandler } from "./inline/strike";
 import { ImageHandler, LinkHandler } from "./inline/link";
+import { HtmlBlockHandler } from "./html";
 
 export const registerPlugin = (
   processor: DocProcessor,
@@ -25,6 +26,7 @@ export const registerPlugin = (
 ) => {
   addToLexer(processor.getLexer(), true);
   const bm = processor.getBlockManager();
+  bm.addHandler(new HtmlBlockHandler());
   bm.addHandler(new BlockquoteHandler());
   bm.addHandler(new CodeHandler());
   bm.addHandler(new HeaderHandler());

--- a/src/plugins/markdown/inline/html-tag.ts
+++ b/src/plugins/markdown/inline/html-tag.ts
@@ -1,0 +1,154 @@
+import { BaseHandler } from "../../../inline/handlers/base";
+import {
+  HandlerInterface,
+  InlineActions,
+  InlineHandlerType,
+  LexemeDef,
+} from "../../../types";
+import {
+  REGEX_HTML_TAG_UNVALIDATED_START_CLOSE,
+  REGEX_HTML_TAG_UNVALIDATED_START_OPEN,
+} from "../lexdef.lookaheads";
+
+export enum HtmlTagState {
+  start,
+  tag_start,
+  tag_open,
+  tag_closing,
+  tag_closed,
+}
+
+/**
+ * Properly follows state of tag tokens to only apply embedded formatting to the tag.
+ * Currently expects attribute values to be properly encoded (more specifically, `>`
+ * literal shouldn't be in there).
+ */
+export class HtmlTagHandler extends BaseHandler {
+  nextAction(lexeme: string): InlineActions {
+    if (this.state == HtmlTagState.tag_closed) return InlineActions.REJECT;
+    else if (this.state == HtmlTagState.tag_open) return InlineActions.DEFER;
+    else return InlineActions.CONTINUE;
+  }
+
+  canAccept(lexeme: string): boolean {
+    return REGEX_HTML_TAG_UNVALIDATED_START_OPEN.test(lexeme);
+  }
+
+  cloneInstance(): HandlerInterface<InlineHandlerType> {
+    return new HtmlTagHandler();
+  }
+
+  getName(): string {
+    return "html-tag";
+  }
+
+  state = HtmlTagState.start;
+  lastLex = "";
+  lastLexEsc = false;
+  tagName = "";
+
+  push(lexeme: string, def: LexemeDef | undefined): any {
+    let ret = InlineActions.REJECT;
+    switch (this.state) {
+      case HtmlTagState.start:
+        ret = this.handleStart(lexeme, def);
+        break;
+      case HtmlTagState.tag_start:
+        ret = this.handleTagStart(lexeme, def);
+        break;
+      case HtmlTagState.tag_open:
+        ret = this.handleTagOpen(lexeme, def);
+        break;
+      case HtmlTagState.tag_closing:
+        ret = this.handleTagClosing(lexeme, def);
+        break;
+      case HtmlTagState.tag_closed:
+        ret = this.handleTagClosed(lexeme, def);
+        break;
+    }
+
+    this.lastLex = lexeme;
+    this.lastLexEsc = lexeme == "\\";
+    return ret;
+  }
+
+  toString() {
+    return this.words.join("");
+  }
+
+  /**
+   * Returns true if '/>' is found in lexeme.
+   * @param lexeme
+   */
+  isInlineTagEnd(lexeme: string) {
+    return lexeme.indexOf("/>") > -1;
+  }
+
+  isTagStartDone(lexeme: string) {
+    return lexeme.indexOf(">") > -1;
+  }
+
+  private handleStart(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): InlineActions {
+    if (REGEX_HTML_TAG_UNVALIDATED_START_OPEN.test(lexeme)) {
+      this.tagName = lexeme.substr(1);
+      this.words.push(lexeme);
+      this.state = HtmlTagState.tag_start;
+      return InlineActions.NEST;
+    }
+
+    return InlineActions.REJECT;
+  }
+
+  private handleTagStart(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): InlineActions {
+    this.words.push(lexeme);
+    if (this.isInlineTagEnd(lexeme)) {
+      this.state = HtmlTagState.tag_closed;
+      return InlineActions.POP;
+    } else if (this.isTagStartDone(lexeme)) {
+      this.state = HtmlTagState.tag_open;
+      return InlineActions.DEFER;
+    }
+    return InlineActions.CONTINUE;
+  }
+
+  private handleTagOpen(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): InlineActions {
+    this.words.push(lexeme);
+    if (
+      REGEX_HTML_TAG_UNVALIDATED_START_CLOSE.test(lexeme) &&
+      this.tagName == lexeme.substr(2)
+    ) {
+      this.state = HtmlTagState.tag_closing;
+      return InlineActions.CONTINUE;
+    }
+
+    return InlineActions.DEFER;
+  }
+
+  private handleTagClosing(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): InlineActions {
+    if (lexeme !== ">") {
+      return InlineActions.REJECT;
+    }
+    this.words.push(lexeme);
+    this.state = HtmlTagState.tag_closed;
+    return InlineActions.POP;
+  }
+
+  private handleTagClosed(
+    lexeme: string,
+    def: LexemeDef | undefined
+  ): InlineActions {
+    return InlineActions.REJECT;
+  }
+}

--- a/src/plugins/markdown/lexdef.commonmark.ts
+++ b/src/plugins/markdown/lexdef.commonmark.ts
@@ -3,7 +3,10 @@ import {
   LexemeLookaheadReturn,
   LexerInterface,
 } from "../../types";
-import { startingListItemDashStarLookahead } from "./lexdef.lookaheads";
+import {
+  startHtmlTagLookahead,
+  startingListItemDashStarLookahead,
+} from "./lexdef.lookaheads";
 import { LEXEME_KEY_NUM, numberDefinition, numberLookahead } from "../../lexer";
 
 const TYPE_NEWLINE = "whitespace:newline";
@@ -40,16 +43,17 @@ const LEXEME_TYPE_BRACKET = "[]";
 const LEXEME_TYPE_IMG_START = "![";
 const LEXEME_TYPE_PUNCTUATION = ".!?";
 const LEXEME_TYPE_PIPE = "|";
+const LEXEME_TYPE_HTML_TAG = "<html-tag";
 
 const SPECIAL_TOKENS: LexemeDefMap = {
   "\\": { priority: 99, type: LEXEME_TYPE_ESCAPE },
   _: {
-    priority: 20,
+    priority: 2,
     upTo: 2,
     type: LEXEME_TYPE_UNDERSCORE,
   },
   [LEXEME_KEY_NUM]: {
-    priority: 20,
+    priority: 2,
     type: "number",
     lookahead: (content, lexeme, i, curDef) => {
       let lookahead = startingListItemDashStarLookahead(
@@ -65,29 +69,34 @@ const SPECIAL_TOKENS: LexemeDefMap = {
     },
   },
   "*": {
-    priority: 20,
+    priority: 2,
     upTo: 2,
     type: LEXEME_TYPE_STAR,
     lookahead: startingListItemDashStarLookahead,
   },
   "-": {
-    priority: 20,
+    priority: 2,
     type: LEXEME_TYPE_DASH,
     lookahead: startingListItemDashStarLookahead,
   },
-  "~": { priority: 20, upTo: 100, type: LEXEME_TYPE_TILDE }, // @todo maybe do -1 instead
-  "`": { priority: 20, upTo: 3, type: LEXEME_TYPE_BACKTICK }, // @todo redo this as a lookahead so we only return for ` or ```, not ``
-  "=": { priority: 20, upTo: 3, type: LEXEME_TYPE_EQUAL },
-  ">": { priority: 20, upTo: 5, type: LEXEME_TYPE_GREATER }, // could do more?
-  "#": { priority: 20, upTo: 6, type: LEXEME_TYPE_HASH },
-  "(": { priority: 20, type: LEXEME_TYPE_PARENTHESIS },
-  ")": { priority: 20, type: LEXEME_TYPE_PARENTHESIS },
-  "[": { priority: 20, type: LEXEME_TYPE_BRACKET },
-  "]": { priority: 20, type: LEXEME_TYPE_BRACKET },
+  "<": {
+    priority: 2,
+    type: LEXEME_TYPE_HTML_TAG,
+    lookahead: startHtmlTagLookahead,
+  },
+  "~": { priority: 2, upTo: 100, type: LEXEME_TYPE_TILDE }, // @todo maybe do -1 instead
+  "`": { priority: 2, upTo: 3, type: LEXEME_TYPE_BACKTICK }, // @todo redo this as a lookahead so we only return for ` or ```, not ``
+  "=": { priority: 2, upTo: 3, type: LEXEME_TYPE_EQUAL },
+  ">": { priority: 2, upTo: 5, type: LEXEME_TYPE_GREATER }, // could do more?
+  "#": { priority: 2, upTo: 6, type: LEXEME_TYPE_HASH },
+  "(": { priority: 2, type: LEXEME_TYPE_PARENTHESIS },
+  ")": { priority: 2, type: LEXEME_TYPE_PARENTHESIS },
+  "[": { priority: 2, type: LEXEME_TYPE_BRACKET },
+  "]": { priority: 2, type: LEXEME_TYPE_BRACKET },
   "![": { priority: 21, type: LEXEME_TYPE_IMG_START },
-  "!": { priority: 20, type: LEXEME_TYPE_PUNCTUATION },
-  ".": { priority: 20, type: LEXEME_TYPE_PUNCTUATION },
-  "?": { priority: 20, type: LEXEME_TYPE_PUNCTUATION },
+  "!": { priority: 2, type: LEXEME_TYPE_PUNCTUATION },
+  ".": { priority: 2, type: LEXEME_TYPE_PUNCTUATION },
+  "?": { priority: 2, type: LEXEME_TYPE_PUNCTUATION },
   "|": { priority: 21, type: LEXEME_TYPE_PIPE },
 };
 

--- a/src/plugins/markdown/lexdef.commonmark.ts
+++ b/src/plugins/markdown/lexdef.commonmark.ts
@@ -44,6 +44,7 @@ const LEXEME_TYPE_IMG_START = "![";
 const LEXEME_TYPE_PUNCTUATION = ".!?";
 const LEXEME_TYPE_PIPE = "|";
 const LEXEME_TYPE_HTML_TAG = "<html-tag";
+const LEXEME_TYPE_HTML_TAG_INLINE_CLOSE = "<html-tag: />";
 
 const SPECIAL_TOKENS: LexemeDefMap = {
   "\\": { priority: 99, type: LEXEME_TYPE_ESCAPE },
@@ -88,6 +89,7 @@ const SPECIAL_TOKENS: LexemeDefMap = {
   "`": { priority: 2, upTo: 3, type: LEXEME_TYPE_BACKTICK }, // @todo redo this as a lookahead so we only return for ` or ```, not ``
   "=": { priority: 2, upTo: 3, type: LEXEME_TYPE_EQUAL },
   ">": { priority: 2, upTo: 5, type: LEXEME_TYPE_GREATER }, // could do more?
+  "/>": { priority: 2, type: LEXEME_TYPE_HTML_TAG_INLINE_CLOSE },
   "#": { priority: 2, upTo: 6, type: LEXEME_TYPE_HASH },
   "(": { priority: 2, type: LEXEME_TYPE_PARENTHESIS },
   ")": { priority: 2, type: LEXEME_TYPE_PARENTHESIS },

--- a/src/plugins/markdown/lexdef.lookaheads.ts
+++ b/src/plugins/markdown/lexdef.lookaheads.ts
@@ -150,3 +150,32 @@ export const consumeRepeatingChars = (
 
   return char.repeat(found);
 };
+
+/**
+ * Unvalidated, loose interpretation of tag start.
+ */
+export const REGEX_HTML_TAG_UNVALIDATED_START = /^(<\/?[^\s]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START_OPEN = /^(<[^\s]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START_CLOSE = /^(<\/[^\s]+)/;
+export const LEXEME_TYPE_HTML_TAG_START = "html:tag-start";
+
+export const startHtmlTagLookahead = (
+  content: string,
+  lexeme: string,
+  i: number,
+  curDef: LexemeDef
+): LexemeLookaheadReturn | any => {
+  const tagSubstr = content.substr(i - lexeme.length, 20);
+  const tagMatch = tagSubstr.match(REGEX_HTML_TAG_UNVALIDATED_START);
+  if (!tagMatch) {
+    return;
+  }
+
+  return {
+    newLexeme: tagMatch[1],
+    nextIndex: i - lexeme.length + tagMatch[1].length,
+    newLexemeDef: {
+      type: LEXEME_TYPE_HTML_TAG_START,
+    },
+  };
+};

--- a/src/plugins/markdown/lexdef.lookaheads.ts
+++ b/src/plugins/markdown/lexdef.lookaheads.ts
@@ -154,9 +154,9 @@ export const consumeRepeatingChars = (
 /**
  * Unvalidated, loose interpretation of tag start.
  */
-export const REGEX_HTML_TAG_UNVALIDATED_START = /^(<\/?[^\s>]+)/;
-export const REGEX_HTML_TAG_UNVALIDATED_START_OPEN = /^(<[^\s>]+)/;
-export const REGEX_HTML_TAG_UNVALIDATED_START_CLOSE = /^(<\/[^\s>]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START = /^(<\/?\w[\w:]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START_OPEN = /^(<\w[\w:]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START_CLOSE = /^(<\/\w[\w:]+)/;
 export const LEXEME_TYPE_HTML_TAG_START = "html:tag-start";
 
 export const startHtmlTagLookahead = (

--- a/src/plugins/markdown/lexdef.lookaheads.ts
+++ b/src/plugins/markdown/lexdef.lookaheads.ts
@@ -154,9 +154,9 @@ export const consumeRepeatingChars = (
 /**
  * Unvalidated, loose interpretation of tag start.
  */
-export const REGEX_HTML_TAG_UNVALIDATED_START = /^(<\/?[^\s]+)/;
-export const REGEX_HTML_TAG_UNVALIDATED_START_OPEN = /^(<[^\s]+)/;
-export const REGEX_HTML_TAG_UNVALIDATED_START_CLOSE = /^(<\/[^\s]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START = /^(<\/?[^\s>]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START_OPEN = /^(<[^\s>]+)/;
+export const REGEX_HTML_TAG_UNVALIDATED_START_CLOSE = /^(<\/[^\s>]+)/;
 export const LEXEME_TYPE_HTML_TAG_START = "html:tag-start";
 
 export const startHtmlTagLookahead = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type LexemeDef = {
   lookahead?: (
     content: string,
     lexeme: string,
-    i: number,
+    nextIdx: number,
     curDef: LexemeDef
   ) => LexemeLookaheadReturn | any;
 };


### PR DESCRIPTION
treats specific block-level html elements as a unit (i.e everything enclosed inside `<div />` will be one block). inline formatting applies to those; however, specific elements (like `<style />`) will pass through as-is. there's also an inline tag handler that only applies formatting to content within the tag itself