### PR TITLE
Generic enhancements

### DIFF
--- a/lib/handler-manager.js
+++ b/lib/handler-manager.js
@@ -7,9 +7,9 @@ exports.insertBefore = (handler, idx, handlers) => {
     }
     else {
         return [
-            ...handlers.splice(0, idx),
+            ...handlers.slice(0, idx),
             handler,
-            ...handlers.splice(idx, handlers.length),
+            ...handlers.slice(idx, handlers.length),
         ];
     }
 };
@@ -19,9 +19,9 @@ exports.insertAfter = (handler, idx, handlers) => {
     }
     else {
         return [
-            ...handlers.splice(0, idx + 1),
+            ...handlers.slice(0, idx + 1),
             handler,
-            ...handlers.splice(idx + 1, handlers.length),
+            ...handlers.slice(idx + 1, handlers.length),
         ];
     }
 };

--- a/readme.md
+++ b/readme.md
@@ -97,14 +97,14 @@ Pretty simple so far. Now let's look within the block and see what happens with 
     - `italicHandler` is popped
     - stack: `[]`
 
-When you turn the document into a string, you get all the pieces back, aseembled from fragment of HTML returned from the different handlers.
+When you turn the document into a string, you get all the pieces back, assembled from fragments of HTML returned from the different handlers.
 
 That's basically it! You can see it all put together in [<code>readme.example.ts</code>](./readme.example.ts)
 
 Take a deeper dive:
 
 - [Lexemes](./docs/lexer.md)
-- [Block ParserContext](./docs/block-parser.md)
-- [Inline ParserContext](./docs/inline-parser.md)
+- [Block Parser](./docs/block-parser.md)
+- [Inline Parser](./docs/inline-parser.md)
 - [Doc Settings](./docs/doc-settings.md)
 - [Plugins](./docs/plugin.md)

--- a/src/defaults/block-base.ts
+++ b/src/defaults/block-base.ts
@@ -1,9 +1,15 @@
 import {
+  BlockActions,
+  BlockHandlerType,
   ContextAwareInterface,
   DocProcContext,
+  HandlerInterface,
   InlineFormatterDummy,
   InlineFormatterInterface,
+  LexemeDef,
 } from "../types";
+import { NAME_DEFAULT } from "../handler-manager";
+import { isLineEnd, isWhitespace, trimString } from "../utils";
 
 export class BlockBase implements ContextAwareInterface {
   protected context?: DocProcContext;
@@ -12,5 +18,29 @@ export class BlockBase implements ContextAwareInterface {
   setContext(context: DocProcContext) {
     this.context = context;
     this.inlineFormatter = context.getInlineFormatter();
+  }
+}
+
+export class BlockEmptyHandler
+  extends BlockBase
+  implements HandlerInterface<BlockHandlerType> {
+  getName(): string {
+    throw new Error("getName() not defined");
+  }
+
+  canAccept(lexeme: string, def?: LexemeDef): boolean {
+    throw new Error("canAccept() not defined");
+  }
+
+  push(lexeme: string, def?: LexemeDef): BlockActions {
+    throw new Error("push() not defined");
+  }
+
+  cloneInstance(): HandlerInterface<BlockHandlerType> {
+    throw new Error("cloneInstance() not defined");
+  }
+
+  toString() {
+    throw new Error("toString() not defined");
   }
 }

--- a/src/defaults/block-wrappers.ts
+++ b/src/defaults/block-wrappers.ts
@@ -1,0 +1,41 @@
+/**
+ * This set of classes wrap blocks in various ways for deferred processing.
+ * They should only be used **after** the block has finished processing.
+ */
+import { BlockBase, BlockEmptyHandler } from "./block-base";
+
+/**
+ * Coerces block elements to string and joins them with newline.
+ */
+export class BlocksListWrapper extends BlockEmptyHandler {
+  blocks: any[] = [];
+
+  constructor(blocks: any) {
+    super();
+    this.blocks = blocks;
+  }
+
+  toString() {
+    return this.blocks.join("\n");
+  }
+}
+
+/**
+ *
+ */
+export class BlockDecorationWrapper extends BlockEmptyHandler {
+  header: any = "";
+  footer: any = "";
+  block: any = "";
+
+  constructor(block: any, header: any, footer: any) {
+    super();
+    this.block = block;
+    this.header = header;
+    this.footer = footer;
+  }
+
+  toString() {
+    return `${this.header}${this.block}${this.footer}`;
+  }
+}

--- a/src/doc-processor.test.ts
+++ b/src/doc-processor.test.ts
@@ -1,3 +1,4 @@
+import { expect } from "chai";
 import { DocProcessor } from "./doc-processor";
 import {
   BlockActions,
@@ -6,6 +7,7 @@ import {
   HandlerInterface,
   LexemeDef,
 } from "./types";
+import { isLineEnd } from "./utils";
 
 class DummyHandler implements HandlerInterface<BlockHandlerType> {
   static count = 0;
@@ -32,7 +34,7 @@ class DummyHandler implements HandlerInterface<BlockHandlerType> {
     return this.name;
   }
 
-  push(lex: string, def: LexemeDef | undefined) {
+  push(lex: string, def: LexemeDef | undefined): BlockActions {
     if (this.lexemeDone == lex) {
       DummyHandler.receivedLexemes.push([this.name, lex]);
       return BlockActions.DONE;
@@ -51,39 +53,93 @@ class DummyHandler implements HandlerInterface<BlockHandlerType> {
   }
 
   cloneInstance() {
-    const clone = new DummyHandler(this.name, this.accepting);
-    return clone;
+    return new DummyHandler(this.name, this.accepting);
+  }
+
+  toString() {
+    return "";
+  }
+}
+
+class ReorderHandler extends DummyHandler {
+  blocks: any[] = [];
+  canAccept(lexeme: string): boolean {
+    return lexeme == "#";
+  }
+
+  cloneInstance() {
+    return new ReorderHandler(this.name, this.accepting);
+  }
+
+  push(lex: string, def: LexemeDef | undefined): BlockActions {
+    if (lex == "#") {
+      return BlockActions.CONTINUE;
+    } else if (isLineEnd(lex)) {
+      return BlockActions.REORDER;
+    } else {
+      return BlockActions.REJECT;
+    }
+  }
+
+  reorderBlocks(
+    blocks: HandlerInterface<BlockHandlerType>[]
+  ): HandlerInterface<BlockHandlerType>[] {
+    this.blocks.push(blocks.shift());
+    this.blocks.push(blocks.shift());
+    console.log(">>", blocks);
+    return blocks;
+  }
+
+  toString() {
+    return `reordered(${this.blocks.join("\n")})`;
   }
 }
 
 describe("DocProcessor", () => {
-  /*
-	we're expecting the folling:
-	handler1 gets '##' and '@@', and ends on '\n'
-	handler2 gets '!!' and rejects '@@'
-	handler1 gets '@@'
-	*/
-  const subject = new DocProcessor();
-  const lexer = subject.getLexer();
-  lexer.mergeLexemes({
-    "#": { priority: 1, upTo: 2 },
-    "@": { priority: 5, upTo: 2 },
-    "\n": { priority: 2 },
-    "!": { priority: 3, upTo: 2 },
+  it("follows proper handling of block handler transitions", () => {
+    /*
+	  we're expecting the folling:
+	  handler1 gets '##' and '@@', and ends on '\n'
+	  handler2 gets '!!' and rejects '@@'
+	  handler1 gets '@@'
+	  */
+    const subject = new DocProcessor();
+    const lexer = subject.getLexer();
+    lexer.mergeLexemes({
+      "#": { priority: 1, upTo: 2 },
+      "@": { priority: 5, upTo: 2 },
+      "\n": { priority: 2 },
+      "!": { priority: 3, upTo: 2 },
+    });
+
+    const handler1 = new DummyHandler("hash-nl", { "##": true, "@@": true });
+    handler1.lexemeDone = "\n";
+    const handler2 = new DummyHandler("exclamation", { "!!": true });
+
+    subject.getBlockManager().addHandler(handler1);
+    subject.getBlockManager().addHandler(handler2);
+
+    const document = `##@@\n!!@@`;
+    subject.process(document);
+    // @todo expect
   });
 
-  const handler1 = new DummyHandler("hash-nl", { "##": true, "@@": true });
-  // handler1.accepting = ;
-  handler1.lexemeDone = "\n";
-  const handler2 = new DummyHandler("exclamation", { "!!": true });
-  // handler1.accepting = ;
+  it.only("allows block reordering through BlockActions.REORDER", () => {
+    const subject = new DocProcessor();
+    subject.getLexer().mergeLexemes({
+      "#": { priority: 1 },
+      ">": { priority: 1, upTo: 2 },
+      "\n": { priority: 2 },
+    });
 
-  subject.getBlockManager().addHandler(handler1);
-  subject.getBlockManager().addHandler(handler2);
+    const handler1 = new ReorderHandler("reorder", { "#": true });
+    handler1.lexemeDone = "\n";
+    subject.getBlockManager().addHandler(handler1);
 
-  const document = `##@@\n!!@@`;
-
-  it("follows proper handling of block handler transitions", () => {
+    const document = `> p1\n\n> p2\n\n#\n\n> p3`;
     subject.process(document);
+    expect(subject.toString()).to.equal(
+      "reordered(<p>> p1</p>\n<p>> p2</p>)\n<p>> p3</p>"
+    );
   });
 });

--- a/src/doc-processor.test.ts
+++ b/src/doc-processor.test.ts
@@ -124,7 +124,7 @@ describe("DocProcessor", () => {
     // @todo expect
   });
 
-  it.only("allows block reordering through BlockActions.REORDER", () => {
+  it("allows block reordering through BlockActions.REORDER", () => {
     const subject = new DocProcessor();
     subject.getLexer().mergeLexemes({
       "#": { priority: 1 },

--- a/src/doc-processor.test.ts
+++ b/src/doc-processor.test.ts
@@ -81,7 +81,7 @@ class ReorderHandler extends DummyHandler {
     }
   }
 
-  reorderBlocks(
+  modifyBlocks(
     blocks: HandlerInterface<BlockHandlerType>[]
   ): HandlerInterface<BlockHandlerType>[] {
     this.blocks.push(blocks.shift());

--- a/src/doc-processor.ts
+++ b/src/doc-processor.ts
@@ -145,8 +145,8 @@ export class DocProcessor {
             `cannot find a default blockHandler. unable to process lexeme: ${lexeme} (${def})`
           );
         }
-      } else if (result == BlockActions.REORDER && curHandler?.reorderBlocks) {
-        this.blocks = curHandler.reorderBlocks(this.blocks);
+      } else if (result == BlockActions.REORDER && curHandler?.modifyBlocks) {
+        this.blocks = curHandler.modifyBlocks(this.blocks);
         this.parser.setCurrentHandler(undefined);
       }
     };

--- a/src/doc-processor.ts
+++ b/src/doc-processor.ts
@@ -126,7 +126,8 @@ export class DocProcessor {
         }
       }
 
-      if (!this.parser.getCurrentHandler()) {
+      const curHandler = this.parser.getCurrentHandler();
+      if (!curHandler) {
         this.setNewHandler(lexeme, def);
       }
 
@@ -144,6 +145,9 @@ export class DocProcessor {
             `cannot find a default blockHandler. unable to process lexeme: ${lexeme} (${def})`
           );
         }
+      } else if (result == BlockActions.REORDER && curHandler?.reorderBlocks) {
+        this.blocks = curHandler.reorderBlocks(this.blocks);
+        this.parser.setCurrentHandler(undefined);
       }
     };
   }

--- a/src/doc-processor.ts
+++ b/src/doc-processor.ts
@@ -146,7 +146,7 @@ export class DocProcessor {
           );
         }
       } else if (result == BlockActions.REORDER && curHandler?.modifyBlocks) {
-        this.blocks = curHandler.modifyBlocks(this.blocks);
+        this.blocks = curHandler.modifyBlocks([...this.blocks]);
         this.parser.setCurrentHandler(undefined);
       }
     };

--- a/src/handler-manager.test.ts
+++ b/src/handler-manager.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { HandlerManager } from "./handler-manager";
+import { HandlerManager, insertAfter, insertBefore } from "./handler-manager";
 import {
   BlockHandlerType,
   DocProcContext,
@@ -34,6 +34,17 @@ class DummyHandler implements HandlerInterface<BlockHandlerType> {
 }
 
 describe("HandlerManager", () => {
+  it("insertBefore properly splices array", () => {
+    const arr = ["a", "b", "c"];
+    const newArr = insertBefore("d", 1, arr);
+    expect(newArr).to.deep.equal(["a", "d", "b", "c"]);
+  });
+  it("insertAfter properly splices array", () => {
+    const arr = ["a", "b", "c"];
+    const newArr = insertAfter("d", 1, arr);
+    expect(newArr).to.deep.equal(["a", "b", "d", "c"]);
+  });
+
   const subject = new HandlerManager();
   subject.addHandler(
     new DummyHandler("first") as HandlerInterface<BlockHandlerType>

--- a/src/handler-manager.ts
+++ b/src/handler-manager.ts
@@ -10,9 +10,9 @@ export const insertBefore = <T>(handler: T, idx: number, handlers: T[]) => {
     return [handler, ...handlers];
   } else {
     return [
-      ...handlers.splice(0, idx),
+      ...handlers.slice(0, idx),
       handler,
-      ...handlers.splice(idx, handlers.length),
+      ...handlers.slice(idx, handlers.length),
     ];
   }
 };
@@ -22,9 +22,9 @@ export const insertAfter = <T>(handler: T, idx: number, handlers: T[]) => {
     return [...handlers, handler];
   } else {
     return [
-      ...handlers.splice(0, idx + 1),
+      ...handlers.slice(0, idx + 1),
       handler,
-      ...handlers.splice(idx + 1, handlers.length),
+      ...handlers.slice(idx + 1, handlers.length),
     ];
   }
 };

--- a/src/plugins/dinomark/block.test.ts
+++ b/src/plugins/dinomark/block.test.ts
@@ -62,7 +62,8 @@ describe("plugins.dinomark.block", () => {
         invokeDirective(def: DirectiveDefinition, ctx: DocProcContext): any {},
         modifyBlocks(
           blocks: HandlerInterface<BlockHandlerType>[],
-          def
+          def,
+          context
         ): HandlerInterface<BlockHandlerType>[] {
           const lastBlock = blocks.pop();
           return [...blocks, new BlockDecorationWrapper(lastBlock, ">", "<")];

--- a/src/plugins/dinomark/block.test.ts
+++ b/src/plugins/dinomark/block.test.ts
@@ -1,5 +1,23 @@
 import { expect } from "chai";
 import { DinoBlockHandler } from "./block";
+import { DocProcessor } from "../../doc-processor";
+import {
+  DINOMARK_SERVICE_DIRECTIVE,
+  DirectiveDefinition,
+  DirectiveHandler,
+  DirectivesManager,
+} from "./directives";
+import {
+  BlockActions,
+  BlockHandlerType,
+  DocProcContext,
+  HandlerInterface,
+} from "../../types";
+import {
+  BlockDecorationWrapper,
+  BlocksListWrapper,
+} from "../../defaults/block-wrappers";
+import exp = require("constants");
 
 describe("plugins.dinomark.block", () => {
   describe("DinoBlockHandler", () => {
@@ -27,6 +45,58 @@ describe("plugins.dinomark.block", () => {
         action: "text-value",
         parameters: '"string"',
       });
+    });
+
+    it("yields to DirectiveHandler.modifyBlocks", () => {
+      const docproc = new DocProcessor();
+      const context = docproc.makeContext();
+      const dman = new DirectivesManager();
+      context.pluginServicesManager.addService(
+        "dinomark",
+        DINOMARK_SERVICE_DIRECTIVE,
+        dman
+      );
+
+      // this will wrap the previous block with some decorators
+      const blocksModifier: DirectiveHandler = {
+        invokeDirective(def: DirectiveDefinition, ctx: DocProcContext): any {},
+        modifyBlocks(
+          blocks: HandlerInterface<BlockHandlerType>[],
+          def
+        ): HandlerInterface<BlockHandlerType>[] {
+          const lastBlock = blocks.pop();
+          return [...blocks, new BlockDecorationWrapper(lastBlock, ">", "<")];
+        },
+      };
+
+      // map the directiv to the handler
+      const def = { directive: "test", action: "t" };
+      dman.addHandler(blocksModifier, def);
+
+      const subject = new DinoBlockHandler();
+      subject.setContext(context);
+
+      const actions = [
+        "[@",
+        def.directive,
+        "]",
+        ":",
+        " ",
+        def.action,
+        "\n",
+      ].map((t) => subject.push(t));
+      expect(actions.pop()).to.equal(
+        BlockActions.REORDER,
+        "test directive should have signaled REORDER"
+      );
+
+      const blocks = ["a", "b"];
+      const newBlocks = subject.modifyBlocks(([
+        ...blocks,
+      ] as unknown) as HandlerInterface<BlockHandlerType>[]);
+
+      expect(newBlocks[0]).to.equal("a");
+      expect(newBlocks[1].toString()).to.equal(">b<");
     });
   });
 });

--- a/src/plugins/dinomark/block.ts
+++ b/src/plugins/dinomark/block.ts
@@ -81,7 +81,8 @@ export class DinoBlockHandler extends LinkrefParagraphHandler {
       ((this.getHandlerForLastDirective() as DirectiveHandler)
         .modifyBlocks as Function)(
         blocks,
-        this.directives[this.directives.length - 1]
+        this.directives[this.directives.length - 1],
+        this.context as DocProcContext
       ) ?? blocks
     );
   }

--- a/src/plugins/dinomark/directive-handlers/capture.ts
+++ b/src/plugins/dinomark/directive-handlers/capture.ts
@@ -1,0 +1,75 @@
+import { DirectiveHandler, DirectiveDefinition } from "../directives";
+import {
+  BlockHandlerType,
+  DocProcContext,
+  HandlerInterface,
+} from "../../../types";
+import { BlocksListWrapper } from "../../../defaults/block-wrappers";
+import { DinoBlockHandler } from "../block";
+import { VarReferenceAccessor } from "../directives.var";
+
+export class DirectiveCaptureStart implements DirectiveHandler {
+  static readonly DIRECTIVE = "capture";
+  invokeDirective(def: DirectiveDefinition, ctx: DocProcContext): any {}
+}
+
+/**
+ * Removes blocks until block containing `capture` directive is found. If not found, no changes are made
+ */
+export class DirectiveCaptureEnd implements DirectiveHandler {
+  static readonly DIRECTIVE = "end-capture";
+  invokeDirective(def: DirectiveDefinition, ctx: DocProcContext): any {}
+
+  modifyBlocks(
+    blocks: HandlerInterface<BlockHandlerType>[],
+    def: DirectiveDefinition,
+    context: DocProcContext
+  ): HandlerInterface<BlockHandlerType>[] {
+    const capturedBlocks: HandlerInterface<BlockHandlerType>[] = [];
+    const myBlock = blocks.pop() as HandlerInterface<BlockHandlerType>;
+
+    while (blocks.length > 0) {
+      const curBlock = blocks.pop() as HandlerInterface<BlockHandlerType>;
+      const isCapture = DirectiveCaptureEnd.isBlockCaptureStart(curBlock);
+      if (isCapture !== false) {
+        DirectiveCaptureEnd.storeCapturedInVar(
+          capturedBlocks,
+          isCapture,
+          context
+        );
+        return [...blocks, myBlock];
+      }
+
+      capturedBlocks.unshift(curBlock);
+    }
+
+    return [...capturedBlocks, myBlock];
+  }
+
+  private static isBlockCaptureStart(
+    curBlock: HandlerInterface<BlockHandlerType>
+  ): false | { varName: string } {
+    if (curBlock instanceof DinoBlockHandler) {
+      for (let i = 0; i < curBlock.directives.length; i++) {
+        const dirDef = curBlock.directives[i];
+        if (dirDef.directive == DirectiveCaptureStart.DIRECTIVE) {
+          return { varName: dirDef.action };
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private static storeCapturedInVar(
+    capturedBlocks: HandlerInterface<BlockHandlerType>[],
+    captureParams: { varName: string },
+    context: DocProcContext
+  ) {
+    VarReferenceAccessor.setVarInContext(
+      captureParams.varName,
+      new BlocksListWrapper(capturedBlocks),
+      context
+    );
+  }
+}

--- a/src/plugins/dinomark/directives.ts
+++ b/src/plugins/dinomark/directives.ts
@@ -37,7 +37,8 @@ export type DirectiveHandler = {
   invokeDirective: (def: DirectiveDefinition, ctx: DocProcContext) => any;
   modifyBlocks?: (
     blocks: HandlerInterface<BlockHandlerType>[],
-    def: DirectiveDefinition
+    def: DirectiveDefinition,
+    context: DocProcContext
   ) => HandlerInterface<BlockHandlerType>[];
 };
 

--- a/src/plugins/dinomark/directives.ts
+++ b/src/plugins/dinomark/directives.ts
@@ -5,7 +5,13 @@
  * [@directive]: action (parameters)
  * ```
  */
-import { AnyMap, DocProcContext, TypedMap } from "../../types";
+import {
+  AnyMap,
+  BlockHandlerType,
+  DocProcContext,
+  HandlerInterface,
+  TypedMap,
+} from "../../types";
 
 export type DirectiveDefinition = {
   /**
@@ -29,6 +35,10 @@ type LooseContext = { vars?: AnyMap };
  */
 export type DirectiveHandler = {
   invokeDirective: (def: DirectiveDefinition, ctx: DocProcContext) => any;
+  modifyBlocks?: (
+    blocks: HandlerInterface<BlockHandlerType>[],
+    def: DirectiveDefinition
+  ) => HandlerInterface<BlockHandlerType>[];
 };
 
 export const DINOMARK_SERVICE_DIRECTIVE = "directive-manager";
@@ -51,15 +61,18 @@ export class DirectivesManager implements DirectiveHandler {
     return this;
   }
 
+  getHandler(def: DirectiveDefinition): DirectiveHandler | undefined {
+    const key1 = `${def.directive}.${def.action ?? ""}`;
+    const key2 = def.directive + ".";
+    return this.handlers[key1] ?? this.handlers[key2];
+  }
+
   /**
    * Finds either the directive/action or directive handler for the given definition.
    * @param def
    * @param ctx
    */
   invokeDirective(def: DirectiveDefinition, ctx: DocProcContext): any {
-    const key1 = `${def.directive}.${def.action ?? ""}`;
-    const key2 = def.directive + ".";
-    const handler = this.handlers[key1] ?? this.handlers[key2];
-    return handler?.invokeDirective(def, ctx);
+    return this.getHandler(def)?.invokeDirective(def, ctx);
   }
 }

--- a/src/plugins/dinomark/directives.var.ts
+++ b/src/plugins/dinomark/directives.var.ts
@@ -24,7 +24,7 @@ export const RestrictedRootKeys: AnyMap = {
  * - `key.subkey` gets translated as `['key', 'subkey']'
  * - `key.subkey with \.` gets translated as `['key', 'subkey with .']`
  *
- * Some root keys are write-protected by default -- see TODO for list.
+ * Some root keys are write-protected by default -- see {@see RestrictedRootKeys} for list.
  */
 export class VarReferenceGetter implements InlineFormatterInterface {
   keys: any[] = [""];
@@ -97,6 +97,16 @@ export class VarReferenceAccessor extends VarReferenceGetter {
 
     ptr[last] = value;
     return value;
+  }
+
+  static setVarInContext(
+    varName: string,
+    value: any,
+    context: DocProcContext
+  ): VarReferenceAccessor {
+    const acc = new VarReferenceAccessor(varName.split("."));
+    acc.setValue(value, context);
+    return acc;
   }
 }
 

--- a/src/plugins/dinomark/index.test.ts
+++ b/src/plugins/dinomark/index.test.ts
@@ -19,9 +19,19 @@ these two includes should preserve the whitespaces between files.
 
 [@execute]: __test/include.js
 [@execute]: __test/include.js (altEntry?{"k1":["v1"]})
+
+[@capture]: testCapture
+
+hello. this block should be captured.
+
+> this blockquote too should be captured.
+
+[@end-capture]
+
+capture = [][testCapture]
 `;
 
-describe("plugins.dinomark.Full Integration Testing", () => {
+describe.only("plugins.dinomark.Full Integration Testing", () => {
   const vars = {
     sys: {
       sourceRoot: __dirname,
@@ -61,5 +71,11 @@ describe("plugins.dinomark.Full Integration Testing", () => {
 
   it("processes @execute with altEntry", () => {
     expect(html).to.contain('altEntry::{"k1":["v1"]}');
+  });
+
+  it("processes @capture and @end-capture", () => {
+    expect(html).to
+      .contain(`<p>capture = <p>hello. this block should be captured.</p>
+<blockquote><p>this blockquote too should be captured.</p></blockquote></p>`);
   });
 });

--- a/src/plugins/dinomark/index.test.ts
+++ b/src/plugins/dinomark/index.test.ts
@@ -31,7 +31,7 @@ hello. this block should be captured.
 capture = [][testCapture]
 `;
 
-describe.only("plugins.dinomark.Full Integration Testing", () => {
+describe("plugins.dinomark.Full Integration Testing", () => {
   const vars = {
     sys: {
       sourceRoot: __dirname,

--- a/src/plugins/dinomark/index.test.ts
+++ b/src/plugins/dinomark/index.test.ts
@@ -28,11 +28,11 @@ describe("plugins.dinomark.Full Integration Testing", () => {
     },
   };
   const docproc = new DocProcessor({ vars });
-  require("../markdown").registerPlugin(docproc);
-  require("./index").registerPlugin(docproc);
-
   let html = "";
+
   before(() => {
+    require("../markdown").registerPlugin(docproc);
+    require("./index").registerPlugin(docproc);
     docproc.process(markdown);
     html = docproc.toString();
   });
@@ -60,6 +60,6 @@ describe("plugins.dinomark.Full Integration Testing", () => {
   });
 
   it("processes @execute with altEntry", () => {
-    expect(html).to.contain('altEntry::{"k1":["v1"]');
+    expect(html).to.contain('altEntry::{"k1":["v1"]}');
   });
 });

--- a/src/plugins/dinomark/index.ts
+++ b/src/plugins/dinomark/index.ts
@@ -10,6 +10,10 @@ import {
   DirectiveInclude,
   DirectiveProcess,
 } from "./directives.include";
+import {
+  DirectiveCaptureEnd,
+  DirectiveCaptureStart,
+} from "./directive-handlers/capture";
 
 export const registerPlugin = (doc: DocProcessor, opts?: PluginOptions) => {
   const pluginSvc = doc.getPluginServiceManager();
@@ -33,6 +37,12 @@ export const registerPlugin = (doc: DocProcessor, opts?: PluginOptions) => {
   });
   directiveManager.addHandler(new DirectiveExecute(), {
     directive: DirectiveExecute.DIRECTIVE,
+  });
+  directiveManager.addHandler(new DirectiveCaptureStart(), {
+    directive: DirectiveCaptureStart.DIRECTIVE,
+  });
+  directiveManager.addHandler(new DirectiveCaptureEnd(), {
+    directive: DirectiveCaptureEnd.DIRECTIVE,
   });
 
   // @todo register directives in opts

--- a/src/plugins/dinomark/inline.ts
+++ b/src/plugins/dinomark/inline.ts
@@ -75,7 +75,7 @@ export class DinoInlineHandler extends BaseLinkHandler {
   }
 
   toString(): string {
-    return this.link.url.resolveValue(this._context);
+    return `${this.link.url.resolveValue(this._context)}`;
   }
 
   cloneInstance(): HandlerInterface<InlineHandlerType> {

--- a/src/plugins/dinomark/readme.md
+++ b/src/plugins/dinomark/readme.md
@@ -13,6 +13,8 @@ With that in mind, let's look at the extension!
 
 Out of the box, the following are supported:
 
+### Block
+
 |syntax                       |target |description
 |---                          |---    |---
 |`[@var]: key (jsonValue)`    |block  |defines a variable `key` with a JSON-encoded value (e.g. `1`, `true`, `[1,"2"]`, etc.)
@@ -20,6 +22,13 @@ Out of the box, the following are supported:
 |`[@include]: filePath`       |block  |dumps content of file into current block.
 |`[@process]: filePath (opts)`|block  |similar to `@include`, except file will be processed before being included. `opts` (TBD) allows you to pass special instructions, such as input or output format.
 |`[@execute]: filePath (func)`|block  |runs a script! see below
+|`[@capture]: varName`        |block  |starts capture of output for all blocks after this, stored in var `varName`
+|`[@end-capture]:`            |block  |ends capturing of blocks 
+
+### Inline
+
+|syntax                       |target |description
+|---                          |---    |---
 |`[][var.key]`                |inline |outputs value nested under `var.key` or blank string if undefined
 |`[](expression)`             |inline |(future) interprets and executes expression.
 

--- a/src/plugins/markdown/html.test.ts
+++ b/src/plugins/markdown/html.test.ts
@@ -19,7 +19,9 @@ describe("plugins.markdown.html", () => {
   });
   describe("HtmlBlockHandler", () => {
     const docproc = new DocProcessor();
-    registerPlugin(docproc);
+    before(() => {
+      registerPlugin(docproc);
+    });
 
     it("builds html as expected with <p/>", () => {
       const dc = new DocProcessor(docproc.makeContext());

--- a/src/plugins/markdown/html.ts
+++ b/src/plugins/markdown/html.ts
@@ -180,7 +180,7 @@ export class HtmlBlockHandler
 
   protected setToPassthroughPush() {
     this.pusher = (lexeme: string, def?: LexemeDef): any => {
-      this.buff.push(lexeme, def);
+      this.buff.push(lexeme);
     };
   }
 

--- a/src/plugins/markdown/linkref-paragraph.ts
+++ b/src/plugins/markdown/linkref-paragraph.ts
@@ -73,8 +73,10 @@ export class LinkrefParagraphHandler extends ParagraphHandler {
     if (isLineEnd(lexeme)) {
       if (isLineEnd(this.lastLex)) {
         this.lineBuff = [];
+        this.handlerEnd();
         return BlockActions.DONE;
       } else {
+        this.handlerEnd();
         this.refState = LinkrefState.start;
         this.lastLex = lexeme;
         this.lastLexEsc = false;
@@ -116,6 +118,7 @@ export class LinkrefParagraphHandler extends ParagraphHandler {
    */
   protected handleStates(lexeme: string, def?: LexemeDef): BlockActions {
     let ret: BlockActions = BlockActions.REJECT;
+    const lstate = this.refState;
     switch (this.refState) {
       case LinkrefState.start:
         ret = this.handleStart(lexeme, def);

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,10 @@ export class GenericHandlerType {}
 export class BlockHandlerType extends GenericHandlerType {}
 export class InlineHandlerType extends GenericHandlerType {}
 
+/**
+ * Acts as a block of data that accepts/rejects lexemes. Can act as simple as a string buffer or as complex as
+ * a state machine.
+ */
 export interface HandlerInterface<T extends GenericHandlerType>
   extends ContextAwareInterface {
   /**
@@ -132,6 +136,11 @@ export interface HandlerInterface<T extends GenericHandlerType>
    * Gives the handler a lexeme. Handler can either consume or reject it.
    */
   push: LexemeConsumer;
+  /**
+   * Allows block to manipulate the blocks before it. This allows for doing things like capturing output of blocks
+   * and storing them in a variable.
+   */
+  reorderBlocks?: (blocks: HandlerInterface<T>[]) => HandlerInterface<T>[];
   /**
    * If available, this method will be called when the document ends to allow for any cleanup
    * of the last handler. This generally is needed when the document doesn't terminate with
@@ -164,6 +173,11 @@ export enum BlockActions {
    * Active block rejects the current lexeme (retry with another handler) and will no longer accept new ones.
    */
   REJECT = "reject",
+  /**
+   * Allows current block to manipulate processed blocks before it by calling handler's `reorderBlocks()` method if it exists.
+   * If method does not exist, gets treated as `DONE`.
+   */
+  REORDER = "reorder",
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,7 @@ export interface HandlerInterface<T extends GenericHandlerType>
    * Allows block to manipulate the blocks before it. This allows for doing things like capturing output of blocks
    * and storing them in a variable.
    */
-  reorderBlocks?: (blocks: HandlerInterface<T>[]) => HandlerInterface<T>[];
+  modifyBlocks?: (blocks: HandlerInterface<T>[]) => HandlerInterface<T>[];
   /**
    * If available, this method will be called when the document ends to allow for any cleanup
    * of the last handler. This generally is needed when the document doesn't terminate with


### PR DESCRIPTION
new features + bug fixes:

- bug/HandlerManager: insert before/after inappropriately dropped elements
- bug/Markdown: html handler inappropriately outputting lexeme definition for passthru tags
- doc: fixed some typos
- enhancement: added `BlockActions.REORDER` and `HandlerInterface.modifyBlocks?` for enhanced doc manipulation
- enhancement: started making helper classes for wrapping block(s) for deferred processing/manipulation
- enhancement/Dinomark: `DirectiveHandler.modifyBlocks?` will make `DinoBlockHandler` yield to the directive so that it can manipulate blocks
- enhancement/Dinomark: added `@capture` and `@end-capture` directives